### PR TITLE
Add filter for errors

### DIFF
--- a/mutator/branch/mutateif.go
+++ b/mutator/branch/mutateif.go
@@ -24,8 +24,16 @@ func MutatorIf(pkg *types.Package, info *types.Info, node ast.Node) []mutator.Mu
 	return []mutator.Mutation{
 		{
 			Change: func() {
-				n.Body.List = []ast.Stmt{
-					astutil.CreateNoopOfStatement(pkg, info, n.Body),
+				containsErr := strings.Contains(fmt.Sprintf("%v", n.Cond), "err")
+				containsNilCheck := strings.Contains(fmt.Sprintf("%v", n.Cond), "!= nil")
+​
+				if !(containsErr && containsNilCheck && len(n.Body.List) == 1) {
+					fmt.Println("Contains error: false\n", "Expression: ", n.Cond)
+					n.Body.List = []ast.Stmt{
+						astutil.CreateNoopOfStatement(pkg, info, n.Body),
+					}
+				} else {
+					fmt.Println("Skipped\n", "Expression: ", n.Cond)
 				}
 			},
 			Reset: func() {

--- a/mutator/branch/mutateif.go
+++ b/mutator/branch/mutateif.go
@@ -28,18 +28,17 @@ func MutatorIf(pkg *types.Package, info *types.Info, node ast.Node) []mutator.Mu
 	
 	if containsErr && containsNilCheck && len(n.Body.List) == 1 {
 		return nil
-	} else {
-		return []mutator.Mutation{
-			{
-				Change: func() {
-					n.Body.List = []ast.Stmt{
-						astutil.CreateNoopOfStatement(pkg, info, n.Body),
-					}
-				},
-				Reset: func() {
-					n.Body.List = old
-				},
+	}
+	return []mutator.Mutation{
+		{
+			Change: func() {
+				n.Body.List = []ast.Stmt{
+					astutil.CreateNoopOfStatement(pkg, info, n.Body),
+				}
 			},
-		}
+			Reset: func() {
+				n.Body.List = old
+			},
+		},
 	}
 }


### PR DESCRIPTION
Closes: https://github.com/osmosis-labs/osmosis/issues/2116

The standard implementation for go-mutesting has a lot of noise in the form of trivial mutations, many of which are removals of `panic` or `err` return statements. This PR intends to introduce a filter to catch these cases to make mutation testing more useful for our main repo.

### Primary approach

- Add a condition to branch mutations with the general logic of:
```
if the if statement has the condition err != nil and one line in its body, return nil
else, return standard branch mutation
```
